### PR TITLE
Create README + use pnpm for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,29 @@
-# Turborepo starter
+# Code diffing tool
 
-This is an official pnpm starter turborepo.
-
-## What's inside?
-
-This turborepo uses [pnpm](https://pnpm.io) as a package manager. It includes the following packages/apps:
-
-### Apps and Packages
-
-- `docs`: a [Next.js](https://nextjs.org/) app
-- `web`: another [Next.js](https://nextjs.org/) app
-- `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `tsconfig`: `tsconfig.json`s used throughout the monorepo
-
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Utilities
-
-This turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
-
-### Build
-
-To build all apps and packages, run the following command:
+**Install**:
 
 ```
-cd my-turborepo
-pnpm run build
+pnpm i
 ```
 
-### Develop
-
-To develop all apps and packages, run the following command:
+**Build**:
 
 ```
-cd my-turborepo
+pnpm build
+```
+
+**Preview + make changes**:
+
+```
+cd animator-app
 pnpm run dev
 ```
 
-### Remote Caching
+Save video by pressing 💾 icon and saving to `apps/remotion-builder/Code-1-project.json`.
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/repo/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
-
-By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup), then enter the following commands:
+**Render a video**:
 
 ```
-cd my-turborepo
-pnpm dlx turbo login
+cd remotion-builder
+pnpm run build
 ```
-
-This will authenticate the Turborepo CLI with your [Vercel account](https://vercel.com/docs/concepts/personal-accounts/overview).
-
-Next, you can link your Turborepo to your Remote Cache by running the following command from the root of your turborepo:
-
-```
-pnpm dlx turbo link
-```
-
-## Useful Links
-
-Learn more about the power of Turborepo:
-
-- [Tasks](https://turbo.build/repo/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/repo/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/repo/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/repo/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/repo/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/repo/docs/reference/command-line-reference)

--- a/apps/remotion-builder/package.json
+++ b/apps/remotion-builder/package.json
@@ -33,6 +33,5 @@
     "prettier": "^2.8.1",
     "tsconfig": "workspace:*",
     "typescript": "^4.9.4"
-  },
-  "packageManager": "npm@8.11.0"
+  }
 }


### PR DESCRIPTION
- Add a README so people have some barebones instructions for how to use the tool
- Removed `npm` as package manager so `pnpm run build` from the root will suceed